### PR TITLE
Use RGB8 type from rgb crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-leds-trait"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David Sawatzke <david-sawatzke@users.noreply.github.com>"]
 edition = "2018"
 categories = [
@@ -15,3 +15,4 @@ repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 
 
 [dependencies]
+rgb = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,7 @@
 #![no_std]
 
-#[derive(Copy, Clone, Default)]
-pub struct Color {
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
-}
+pub type Color = rgb::RGB8;
 
-impl From<(u8, u8, u8)> for Color {
-    fn from(color_tuple: (u8, u8, u8)) -> Self {
-        Self {
-            r: color_tuple.0,
-            g: color_tuple.1,
-            b: color_tuple.2,
-        }
-    }
-}
 pub trait SmartLedsWrite {
     type Error;
     fn write<T>(&mut self, iterator: T) -> Result<(), Self::Error>


### PR DESCRIPTION
Implement https://github.com/smart-leds-rs/smart-leds-trait/issues/1

Should be fine semver wise, RGB8 luckily implements `From` tuple