### PR TITLE
Add attributes to White structure for compatible with rgb library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub use {rgb::RGB, rgb::RGB16, rgb::RGB8, rgb::RGBA};
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct White<C>(pub C);
 
 /// The RGBW Pixel


### PR DESCRIPTION
Add deriving of Debug, Clone, Copy for `White` structure - it needs for another part of library where we use RGBW structures.