### PR TITLE
Replace Iterator with IntoIterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,6 @@ pub trait SmartLedsWrite {
     type Color;
     fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
     where
-        T: Iterator<Item = I>,
+        T: IntoIterator<Item = I>,
         I: Into<Self::Color>;
 }


### PR DESCRIPTION
**Rationale:** `IntoIterator` can take everything `Iterator` can, plus it can take `&[..]` slice references directly without requiring `.iter()`.

So for parameters, `IntoIterator` is always preferred.

This is a non-breaking change for people *calling* the trait function, but it is a breaking change for people *implementing* the trait, so it should be marked with a major semver change.