### PR TITLE
feat: add serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 
 [dependencies]
 rgb = "0.8"
+
+[features]
+serde = ["rgb/serde"]


### PR DESCRIPTION
This solves https://github.com/smart-leds-rs/smart-leds/issues/16.
(I only serialize/deserialize colors programatically as/to JSON so I dont need to be able to deserialize contants like "WHITE" or "BLACK", only previously programatically serialized json like {"r":255,"g":0,"b":0}).