### PR TITLE
Add async trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 
 [dependencies]
 rgb = "0.8"
+embedded-hal-async = "1.0"
 
 [features]
 serde = ["rgb/serde"]

--- a/src/asynch/mod.rs
+++ b/src/asynch/mod.rs
@@ -1,0 +1,14 @@
+use core::future::Future;
+
+/// An async trait that smart led drivers implement
+///
+/// The amount of time each iteration of `iterator` might take is undefined.
+/// Drivers, where this might lead to issues, aren't expected to work in all cases.
+pub trait SmartLedsWrite {
+    type Error;
+    type Color;
+    fn write<T, I>(&mut self, iterator: T) -> impl Future<Output = Result<(), Self::Error>>
+    where
+        T: IntoIterator<Item = I>,
+        I: Into<Self::Color>;
+}

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -1,0 +1,12 @@
+/// A trait that smart led drivers implement
+///
+/// The amount of time each iteration of `iterator` might take is undefined.
+/// Drivers, where this might lead to issues, aren't expected to work in all cases.
+pub trait SmartLedsWrite {
+    type Error;
+    type Color;
+    fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
+    where
+        T: IntoIterator<Item = I>,
+        I: Into<Self::Color>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 //! crate, which contains various convenience functions.
 #![no_std]
 
+pub mod asynch;
+pub mod blocking;
+
 pub use {rgb::RGB, rgb::RGB16, rgb::RGB8, rgb::RGBA};
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -22,16 +25,3 @@ pub struct White<C>(pub C);
 /// This is used for leds, that in addition to RGB leds also contain a white led
 pub type RGBW<ComponentType, WhiteComponentType = ComponentType> =
     RGBA<ComponentType, White<WhiteComponentType>>;
-
-/// A trait that smart led drivers implement
-///
-/// The amount of time each iteration of `iterator` might take is undefined.
-/// Drivers, where this might lead to issues, aren't expected to work in all cases.
-pub trait SmartLedsWrite {
-    type Error;
-    type Color;
-    fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
-    where
-        T: IntoIterator<Item = I>,
-        I: Into<Self::Color>;
-}


### PR DESCRIPTION
As per my comment https://github.com/smart-leds-rs/smart-leds-trait/issues/12#issuecomment-2508968288, I allowed myself to make a suggestion for an async trait implementation, which now lives in the `asynch` submodule.

Furthermore I moved the original, blocking trait into the `blocking` submodule for consistency. Let me know what you think!

You can see an implementation of the trait here: https://github.com/kalkyl/ws2812-async/pull/7

Closes #12 