### PR TITLE
use `async fn` for async trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@ pub trait SmartLedsWrite {
 }
 
 pub mod asynch {
-    use core::future::Future;
-
     /// An async trait that Smart Led Drivers implement
     ///
     /// The amount of time each iteration of `iterator` might take is undefined.
@@ -46,7 +44,18 @@ pub mod asynch {
     pub trait SmartLedsWriteAsync {
         type Error;
         type Color;
-        fn write<T, I>(&mut self, iterator: T) -> impl Future<Output = Result<(), Self::Error>>
+        // The async_fn_in_trait warning doesn't really matter for embedded cases because
+        // no_std async executors don't require futures to be Send. Also, embedded-hal-async
+        // does not have Send bounds in its traits, so the HAL functions called in
+        // implementations of this trait wouldn't return Send futures anyway. It's
+        // questionable if it would be desirable for embedded HALs to return a Send future
+        // for the write function for a peripheral because you probably don't want to
+        // write data to the same peripheral from multiple threads simultaneously and have
+        // the data get interleaved, nor have the embedded HAL implement a synchronization
+        // mechanism with a run time cost to avoid that.
+        // https://github.com/rust-embedded/embedded-hal/pull/515#issuecomment-1763525962
+        #[allow(async_fn_in_trait)]
+        async fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
         where
             T: IntoIterator<Item = I>,
             I: Into<Self::Color>;


### PR DESCRIPTION
for readability

A Send variant may be nice to use with Embassy's SendSpawner. However, embedded-hal-async traits don't have Send variants, so it's unlikely the that the drivers called in the impl's of this trait would have async fn's that return Send Futures. You probably don't want to be writing different frames to one LED device from multiple threads simultaneously anyway; that would require the driver to implement synchronization to avoid interleaving of separate frames, which would add a run time cost.