### PR TITLE
remove dependency on rgb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,3 @@ documentation = "https://docs.rs/crate/smart-leds-trait"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/smart-leds-rs/smart-leds-trait"
-
-[dependencies]
-rgb = "0.8"
-
-[features]
-serde = ["rgb/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,6 @@
 //! crate, which contains various convenience functions.
 #![no_std]
 
-pub use {rgb::RGB, rgb::RGB16, rgb::RGB8, rgb::RGBA};
-
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct White<C>(pub C);
-
-/// The RGBW Pixel
-///
-/// This is used for leds, that in addition to RGB leds also contain a white led
-pub type RGBW<ComponentType, WhiteComponentType = ComponentType> =
-    RGBA<ComponentType, White<WhiteComponentType>>;
-
 /// A trait that Smart Led Drivers implement
 ///
 /// The amount of time each iteration of `iterator` might take is undefined.


### PR DESCRIPTION
Since b9392f9a7ae2e85fb1c79bfe49b7d16fbe39455b this crate no longer uses types from rgb in the public trait. The White and RGBW are also not used in the trait, so I don't think they belong in this crate. If White and RGBW are still desirable for downstreams, I suggest to move them to the smart-leds crate instead of this crate.