### PR TITLE
add blocking and async Cargo features with blocking as default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,10 @@ repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 rgb = "0.8"
 
 [features]
+default = [ "blocking" ]
+blocking = []
+async = []
 serde = ["rgb/serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,19 +23,27 @@ pub struct White<C>(pub C);
 pub type RGBW<ComponentType, WhiteComponentType = ComponentType> =
     RGBA<ComponentType, White<WhiteComponentType>>;
 
-/// A trait that Smart Led Drivers implement
-///
-/// The amount of time each iteration of `iterator` might take is undefined.
-/// Drivers, where this might lead to issues, aren't expected to work in all cases.
-pub trait SmartLedsWrite {
-    type Error;
-    type Color;
-    fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
-    where
-        T: IntoIterator<Item = I>,
-        I: Into<Self::Color>;
+#[cfg(feature = "blocking")]
+pub mod blocking {
+    /// A trait that Smart Led Drivers implement
+    ///
+    /// The amount of time each iteration of `iterator` might take is undefined.
+    /// Drivers, where this might lead to issues, aren't expected to work in all cases.
+    pub trait SmartLedsWrite {
+        type Error;
+        type Color;
+        fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
+        where
+            T: IntoIterator<Item = I>,
+            I: Into<Self::Color>;
+    }
 }
 
+// for backwards compatibility
+#[cfg(feature = "blocking")]
+pub use blocking::SmartLedsWrite;
+
+#[cfg(feature = "async")]
 pub mod asynch {
     /// An async trait that Smart Led Drivers implement
     ///


### PR DESCRIPTION
To let downstream users choose only what they need.

Unlike #13, the `pub use blocking::SmartLedsWrite` preserves backwards compatibility.