### PR TITLE
remove asynch module; move SmartLedsWriteAsync to top level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-leds-trait"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["David Sawatzke <david-sawatzke@users.noreply.github.com>"]
 edition = "2021"
 categories = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,28 +36,26 @@ pub trait SmartLedsWrite {
         I: Into<Self::Color>;
 }
 
-pub mod asynch {
-    /// An async trait that Smart Led Drivers implement
-    ///
-    /// The amount of time each iteration of `iterator` might take is undefined.
-    /// Drivers, where this might lead to issues, aren't expected to work in all cases.
-    pub trait SmartLedsWriteAsync {
-        type Error;
-        type Color;
-        // The async_fn_in_trait warning doesn't really matter for embedded cases because
-        // no_std async executors don't require futures to be Send. Also, embedded-hal-async
-        // does not have Send bounds in its traits, so the HAL functions called in
-        // implementations of this trait wouldn't return Send futures anyway. It's
-        // questionable if it would be desirable for embedded HALs to return a Send future
-        // for the write function for a peripheral because you probably don't want to
-        // write data to the same peripheral from multiple threads simultaneously and have
-        // the data get interleaved, nor have the embedded HAL implement a synchronization
-        // mechanism with a run time cost to avoid that.
-        // https://github.com/rust-embedded/embedded-hal/pull/515#issuecomment-1763525962
-        #[allow(async_fn_in_trait)]
-        async fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
-        where
-            T: IntoIterator<Item = I>,
-            I: Into<Self::Color>;
-    }
+/// An async trait that Smart Led Drivers implement
+///
+/// The amount of time each iteration of `iterator` might take is undefined.
+/// Drivers, where this might lead to issues, aren't expected to work in all cases.
+pub trait SmartLedsWriteAsync {
+    type Error;
+    type Color;
+    // The async_fn_in_trait warning doesn't really matter for embedded cases because
+    // no_std async executors don't require futures to be Send. Also, embedded-hal-async
+    // does not have Send bounds in its traits, so the HAL functions called in
+    // implementations of this trait wouldn't return Send futures anyway. It's
+    // questionable if it would be desirable for embedded HALs to return a Send future
+    // for the write function for a peripheral because you probably don't want to
+    // write data to the same peripheral from multiple threads simultaneously and have
+    // the data get interleaved, nor have the embedded HAL implement a synchronization
+    // mechanism with a run time cost to avoid that.
+    // https://github.com/rust-embedded/embedded-hal/pull/515#issuecomment-1763525962
+    #[allow(async_fn_in_trait)]
+    async fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
+    where
+        T: IntoIterator<Item = I>,
+        I: Into<Self::Color>;
 }


### PR DESCRIPTION
It's awkward to have only one of sync and async traits in a submodule. The sync trait could be moved to a submodule, with a `pub use` statement for backwards compatibility. However, as per #19, if there aren't going to be Cargo features for sync & async, then I don't think there's much point having submodules.