### PR TITLE
add ExactSizeIterator trait bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub trait SmartLedsWrite {
     type Color;
     fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
     where
-        T: IntoIterator<Item = I>,
+        T: IntoIterator<Item = I, IntoIter: ExactSizeIterator>,
         I: Into<Self::Color>;
 }
 
@@ -56,6 +56,6 @@ pub trait SmartLedsWriteAsync {
     #[allow(async_fn_in_trait)]
     async fn write<T, I>(&mut self, iterator: T) -> Result<(), Self::Error>
     where
-        T: IntoIterator<Item = I>,
+        T: IntoIterator<Item = I, IntoIter: ExactSizeIterator>,
         I: Into<Self::Color>;
 }


### PR DESCRIPTION
This allows implementations to automatically handle protocol details that depend on the number of LEDs addressed. This is required for sending the correct length for the end frame in the APA102/SK9822 protocol:
https://github.com/smart-leds-rs/apa102-spi-rs/pull/18

AFAIK the only downside to this is that core::iter::Chain doesn't implement ExactSizeIterator. I don't think that generally matters for downstream users, who are most likely passing slices of LED data to SmartLedsWrite::write.