### PR TITLE
adds RGBCCT pixel type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,24 @@ pub use {rgb::RGB, rgb::RGB16, rgb::RGB8, rgb::RGBA};
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct White<C>(pub C);
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct CctWhite<C>{
+    pub cold: C,
+    pub warm: C,
+}
+
 /// The RGBW Pixel
 ///
 /// This is used for leds, that in addition to RGB leds also contain a white led
 pub type RGBW<ComponentType, WhiteComponentType = ComponentType> =
     RGBA<ComponentType, White<WhiteComponentType>>;
+
+
+/// The RGBCCT Pixel
+/// 
+/// This is used for leds that, in addition to RGB leds, also contain two white leds (cold white and warm white)
+pub type RGBCCT<ComponentType, CctWhiteComponentType = ComponentType> =
+    RGBA<ComponentType, CctWhite<CctWhiteComponentType>>;
 
 /// A trait that Smart Led Drivers implement
 ///


### PR DESCRIPTION
Example fix for #23.

This adds a new pixel type that able to drive LEDs with two white LEDs