### PR TITLE
chore(rgb): disable the default features of `rgb`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 
 [dependencies]
-rgb = "0.8"
+rgb = { version = "0.8", default-features = false }
 
 [features]
 serde = ["rgb/serde"]


### PR DESCRIPTION
Thank you for your work on this crate!

Currently (as of `rgb` v0.8.52), the `rgb` crate has three default Cargo features: `argb`, `as-bytes`, `grb`. I believe this crate does not rely on `argb` or `grb`, so this PR proposes to disable these two features by disabling the default features on the `rgb` dependency. This should not have any observable effect and therefore should not be a breaking change.

I am however unsure whether the `as-bytes` Cargo feature could be disabled as well, so I enabled it explicitly for now.
That `as-bytes` feature also enables the `bytemuck` feature and dependency of `rgb` so it would be beneficial to also disable that feature if that is possible, as to avoid that dependency altogether if unused. Disabling the feature does break the `::bytemuck::cast_slice()` link in the documentation of `AsPixels::as_pixels()`, but I do not know whether disabling that feature would actually be a breaking change, as I am not sure how `bytemuck` interacts with this crate.

---

Do feel free to push to this PR branch as needed.