### PR TITLE
Bump RGB version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ readme = "README.md"
 repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 
 [dependencies]
-rgb = "0.8.92-rc.1"
+rgb = { version = "0.8.92-rc.1", default-features = false }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-leds-trait"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["David Sawatzke <david-sawatzke@users.noreply.github.com>"]
-edition = "2021"
+edition = "2024"
 categories = [
     "embedded",
     "no-std",
@@ -14,7 +14,6 @@ readme = "README.md"
 repository = "https://github.com/smart-leds-rs/smart-leds-trait"
 
 [dependencies]
-rgb = { version = "0.8", default-features = false }
+rgb = "0.8.92-rc.1"
 
 [features]
-serde = ["rgb/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,29 +12,25 @@
 //! crate, which contains various convenience functions.
 #![no_std]
 
-pub use {rgb::RGB, rgb::RGB16, rgb::RGB8, rgb::RGBA};
+pub use {rgb::RGB8, rgb::RGB16, rgb::Rgb, rgb::Rgba, rgb::Rgbw};
+
+#[deprecated(
+    since = "0.4.0",
+    note = "Use the Rgb struct instead of the Rgb8 struct"
+)]
+pub use rgb::{RGB, RGBA};
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct White<C>(pub C);
-
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct CctWhite<C>{
+pub struct CctWhite<C> {
     pub cold: C,
     pub warm: C,
 }
 
-/// The RGBW Pixel
-///
-/// This is used for leds, that in addition to RGB leds also contain a white led
-pub type RGBW<ComponentType, WhiteComponentType = ComponentType> =
-    RGBA<ComponentType, White<WhiteComponentType>>;
-
-
 /// The RGBCCT Pixel
-/// 
+///
 /// This is used for leds that, in addition to RGB leds, also contain two white leds (cold white and warm white)
 pub type RGBCCT<ComponentType, CctWhiteComponentType = ComponentType> =
-    RGBA<ComponentType, CctWhite<CctWhiteComponentType>>;
+    Rgba<ComponentType, CctWhite<CctWhiteComponentType>>;
 
 /// A trait that Smart Led Drivers implement
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,6 @@
 
 pub use {rgb::RGB8, rgb::RGB16, rgb::Rgb, rgb::Rgba, rgb::Rgbw};
 
-#[deprecated(
-    since = "0.4.0",
-    note = "Use the Rgb struct instead of the Rgb8 struct"
-)]
-pub use rgb::{RGB, RGBA};
-
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct CctWhite<C> {
     pub cold: C,


### PR DESCRIPTION
Isn't this library supposed to only contain the trait types? RGB is currently introducing various changes. I tried to bump the RGB crate, but why not remove the RGB dependency alltogether and only include the basic traits?

 Then version breakages are limited to `smart-led` and the RGB version change does not spill over to this crate.